### PR TITLE
fix(deps): Relax the minimum required go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grpc-ecosystem/grpc-gateway/v2
 
-go 1.22.7
-
-toolchain go1.23.4
+go 1.22.0
 
 require (
 	github.com/antihax/optional v1.0.0


### PR DESCRIPTION
Setting the `go` directive to a patch version above `.0` causes issues for downstream code bases that have their `go` directive set to the `.0` patch version of Go.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to gRPC-Gateway here: https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md

Happy contributing!

-->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Have you read the [Contributing Guidelines](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/CONTRIBUTING.md)?

#### Brief description of what is fixed or changed

#### Other comments
